### PR TITLE
Docker -> Kubernetes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN set -ex && \
   apt-get update -yqq && \
   apt-get upgrade -yqq && \
   apt-get install -yqq \
-  apt-utils 
+  apt-utils git nano
 
 # Setting the timezone
 ENV TZ "Africa/Johannesburg"

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ ENV LC_MESSAGES en_ZA.UTF-8
 
 # Installing kubernetes-specific python packages
 RUN pip install apache-airflow[kubernetes]==${AIRFLOW_VERSION} \
-    && pip install Flash-OAuthlib
+    && pip install Flask-OAuthlib
 
 # Changing back to the airflow user
 USER airflow

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN set -ex && \
   apt-get update -yqq && \
   apt-get upgrade -yqq && \
   apt-get install -yqq \
-  apt-utils git nano
+  apt-utils 
 
 # Setting the timezone
 ENV TZ "Africa/Johannesburg"

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,4 +47,4 @@ RUN pip install apache-airflow[kubernetes]==${AIRFLOW_VERSION} \
 USER airflow
 
 # Unload examples
-#ENV LOAD_EX "n"
+ENV LOAD_EX "n"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,16 @@
 FROM docker.io/puckel/docker-airflow
 
-LABEL authors="Gordon Inggs"
+LABEL authors="Gordon Inggs and Riaz Arbi"
 
-# Changing back to root to install a few things
+# Changing back to root
 USER root
 
-# Utility packages
+# Adding utility packages
 RUN set -ex && \
   apt-get update -yqq && \
   apt-get upgrade -yqq && \
   apt-get install -yqq \
-  vim \
-  nano \
-  htop \
-  bash \
-  wget \
-  apt-utils \
-  git \
-  sudo
-
-# Installing Docker Python bindings
-RUN DEBIAN_FRONTEND=noninteractive \
-  pip3 install docker
+  apt-utils 
 
 # Setting the timezone
 ENV TZ "Africa/Johannesburg"
@@ -48,15 +37,12 @@ ENV LC_ALL en_ZA.UTF-8
 ENV LC_CTYPE en_ZA.UTF-8
 ENV LC_MESSAGES en_ZA.UTF-8
 
+# Installing kubernetes-specific python packages
+RUN pip install apache-airflow[kubernetes]==${AIRFLOW_VERSION} \
+    && pip install Flash-OAuthlib
+
 # Changing back to the airflow user
 USER airflow
 
-# Creating a DAGs dir in the airflow user's directory
-RUN mkdir /usr/local/airflow/dags
-
-# Using a local executor, and unloading the examples
-ENV EXECUTOR "Local"
-ENV LOAD_EX "n"
-
-# Using the local hostname, as retrieving the FQDN takes a long time
-ENV AIRFLOW__CORE__HOSTNAME_CALLABLE "socket:gethostname"
+# Unload examples
+#ENV LOAD_EX "n"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ LABEL authors="Gordon Inggs and Riaz Arbi"
 
 # Changing back to root
 USER root
+RUN echo AIRFLOW_VERSION
+ARG AIRFLOW_VERSION=1.10.3
 
 # Adding utility packages
 RUN set -ex && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ ENV LC_MESSAGES en_ZA.UTF-8
 
 # Installing kubernetes-specific python packages
 RUN pip install apache-airflow[kubernetes]==${AIRFLOW_VERSION} \
+    && pip install flask_bcrypt \
     && pip install Flask-OAuthlib
 
 # Changing back to the airflow user

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
-# Airflow with Docker
+# Airflow with ~~Docker~~ Kubernetes
 This image builds upon [Puckel's Airflow image](https://github.com/puckel/docker-airflow), specialising it for use as 
-controller of tasks being run in standalone Docker containers (using the Python Docker bindings).
+controller of tasks being run ~~standalone Docker containers (using the Python Docker bindings)~~ in a Kubernetes cluster.
 
-It uses a LocalExecutor to allow for task parallelism, doesn't laod the example, and adds a few utilities as well as
-localising to South Africa, otherwise the config is left as the defaults.
+Please note these instructions are for launching the Docker container standalone. Please head over to the [Kubernetes README](./k8s/README.md)
+to go on the exciting journey of deploying this container as a service within a Kubernetes cluster (which Airflow will
+also use to run tasks).
+
+This airflow configuration uses a LocalExecutor to allow for task parallelism, doesn't load the examples, and adds a few
+utilities as well as localising to South Africa, otherwise the config is left to the defaults.
 
 On the last point, I would be open to a pull request to make this optional as I realise not everyone is lucky enough to
 live in SA.
@@ -18,15 +22,12 @@ live in SA.
              --name airflow-postgres \
              -d postgres
   ```
-2. Now, actually start the airflow container (**NB it's a privileged container**):
+2. Now, actually start the airflow container:
   ```bash
   docker run -e POSTGRES_HOST=<State DB host name> \
              -e POSTGRES_PORT=<State DB port number> \
-             --name docker-airflow \
-             -v /var/run/docker.sock:/var/run/docker.sock:rw \
+             --name k8s-airflow \
              -p <Host port for WUI>:8080 \
-             -p <Docker API port>:8793 \
-             --privileged \
              --restart always \
              -d cityofcapetown/airflow
   ```

--- a/README.md
+++ b/README.md
@@ -2,16 +2,39 @@
 This image builds upon [Puckel's Airflow image](https://github.com/puckel/docker-airflow), specialising it for use as 
 controller of tasks being run in standalone Docker containers (using the Python Docker bindings).
 
-It starts a LocalExecutor to allow for task parallelism, as well adding a few utilities and localises to South Africa.
+It uses a LocalExecutor to allow for task parallelism, doesn't laod the example, and adds a few utilities as well as
+localising to South Africa, otherwise the config is left as the defaults.
 
-As a LocalExecutor is used, a separate Postgret DB is required, i.e.
-```bash
-docker run -e POSTGRES_PASSWORD=airflow \
-           -e POSTGRES_USER=airflow \
-           -e POSTGRES_DB=airflow \
-           -p <host port>:5432 \
-           --name airflow-postgres \
-           -d postgres
-```
+On the last point, I would be open to a pull request to make this optional as I realise not everyone is lucky enough to
+live in SA.
 
-The `POSTGRES_HOST` and `POSTGRES_PORT` variables for the airflow container then need to be set.
+## Getting Started
+1. As a `LocalExecutor` is used, a separate state DB is required. These instructions assume PostgreSQL , i.e.
+  ```bash
+  docker run -e POSTGRES_PASSWORD=airflow \
+             -e POSTGRES_USER=airflow \
+             -e POSTGRES_DB=airflow \
+             -p <host port for state DB>:5432 \
+             --name airflow-postgres \
+             -d postgres
+  ```
+2. Now, actually start the airflow container (**NB it's a privileged container**):
+  ```bash
+  docker run -e POSTGRES_HOST=<State DB host name> \
+             -e POSTGRES_PORT=<State DB port number> \
+             --name docker-airflow \
+             -v /var/run/docker.sock:/var/run/docker.sock:rw \
+             -p <Host port for WUI>:8080 \
+             -p <Docker API port>:8793 \
+             --privileged \
+             --restart always \
+             -d cityofcapetown/airflow
+  ```
+ 3. Once your airflow container has come up, you should be able to access the UI on the `<Host port for WUI>` specified.
+
+## Adding Dags
+The dag files need to be copied to `/usr/local/airflow/dags` inside the container, i.e.
+`docker cp <dag file path> docker-airflow:/usr/local/airflow/dags/`.
+
+Or you can add `-v <path on host system to dag directory>:/usr/local/airflow/dags/` to the run command above to map it
+to a directory on the host system.

--- a/README.md
+++ b/README.md
@@ -2,14 +2,16 @@
 This image builds upon [Puckel's Airflow image](https://github.com/puckel/docker-airflow), specialising it for use as 
 controller of tasks being run ~~standalone Docker containers (using the Python Docker bindings)~~ in a Kubernetes cluster.
 
-Please note these instructions are for launching the Docker container standalone. Please head over to the [Kubernetes README](./k8s/README.md)
+Please note the instructions in this README are for launching this Docker image standalone (i.e. non-Kubernetes). Please head over to the [Kubernetes README](./k8s/README.md)
 to go on the exciting journey of deploying this container as a service within a Kubernetes cluster (which Airflow will
 also use to run tasks).
 
 This airflow configuration uses a LocalExecutor to allow for task parallelism, doesn't load the examples, and adds a few
 utilities as well as localising to South Africa, otherwise the config is left to the defaults.
 
-On the last point, I would be open to a pull request to make this optional as I realise not everyone is lucky enough to
+The reason [the **LocalExecutor**](https://airflow.apache.org/_modules/airflow/executors/local_executor.html) is used is that our intended mode of execution is to offload work directly to Docker or Kubernetes, and so avoid the complication of maintaining a separate work broker.
+
+On the timezone point, I would be open to a pull request to make this optional as I realise not everyone is lucky enough to
 live in SA.
 
 ## Getting Started

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,221 @@
+# Airflow on/with Kubernetes
+These instructions document how to deploy the Airflow Dockerfile in the
+root repo to a Kubernetes cluster. Airflow can then also use the same
+Kubernetes cluster to run work via the 
+[KubernetesPodOperator](https://airflow.readthedocs.io/en/stable/kubernetes.html#kubernetes-operator).
+
+**NB** This doesn't describe how to setup the 
+[KubernetesExecutor](https://airflow.readthedocs.io/en/stable/kubernetes.html#kubernetes-executor),
+which creates pods to execute other types of operators (e.g. Bash, Python).
+
+## Assumptions
+* Kubernetes is up and running (`systemctl status kubelet`)
+* You have `kubectl` installed and talking to the cluster
+* You are running these commands in this directory
+* You're using a NFS storage client with `StorageClassName='nfs-client'`
+* You're using traefik as your frontend service reverse proxy
+
+## 1. Namespace and Role
+First up, we need to handle the permissions end of things.
+
+1. Creating the namespaces, `airflow` (where the service will live), and
+`airflow-workers` (where the KubernetesPodOperator's pods will live, 
+albeit briefly): `kubectl apply -f resources/airflow_namespaces.yaml`
+
+Result:
+```
+namespace/airflow-workers created
+namespace/airflow created
+```
+
+2. Creating the Role, `airflow-role`. This role gives permission to mess 
+with pods in the `airflow-workers` namespace: `kubectl apply -f resources/airflow_role.yaml`
+
+Result:
+```
+role.rbac.authorization.k8s.io/airflow-role created
+```
+
+3. Binding the Role, `airflow-role`, to the `airflow` service account 
+(which doesn't exist yet): `kubectl apply -f resources/airflow_role_bind.yaml`
+
+Result:
+```
+rolebinding.rbac.authorization.k8s.io/airflow-role-bind created
+```
+
+The idea is that the airflow service account can **only** control pods
+in the `airflow-workers` namespace. This means even if Airflow gains
+sentience, goes rogue and tries to kill us all, it can only do so in the
+`airflow-workers` namespace.
+
+## 2. DAG and Log Persistence
+When deploying Airflow as a service, the `dags` and `logs` directories
+need to be shared between the various components.
+
+* Creating persistent volumes. You want to do this is if you want 
+control of exactly where your `dags` and `logs` directories live.
+Command: `kubectl apply -f resources/airflow_volumes.yaml`.
+
+**NB** Your NFS configuration is almost certainly different to ours. 
+You are probably going to have to change the `nfs.server` and `nfs.path`
+keys.
+
+**NBx2** if you decide to the above, you probably want to think carefully about why
+you want such fine-grained control.
+
+* Creating persistent volume claims. You want to do this so that your
+`dags` and `logs` directories persist between airflow deployments:
+`kubectl apply -f resources/airflow_volume_claims.yaml`
+
+Result:
+```
+persistentvolumeclaim/airflow-dags created
+persistentvolumeclaim/airflow-logs created
+```
+
+## 3. Setting Values
+There isn't anything to do here, other than review and change some of
+the values as required in [the supplied file](./resources/airflow-values.yaml).
+
+Of interest:
+* `airflow.fernetKey` - generate something strong for this.
+* `ingress.web.path` - change this to whatever path you would like airflow on.
+* `postgres.*` vs `redis.*` - these control the backend used.
+* `workers.enabled` - enable this if you want persistent workers, which
+is not what we're doing here.
+
+## 4. Applying Helm Chart
+Using the helm stable chart for airflow, with our values overriding the
+configuration: `helm upgrade --install --values resources/airflow-values.yaml --namespace airflow airflow stable/airflow`
+
+Result:
+```
+Release "airflow" does not exist. Installing it now.
+2019/08/14 02:53:29 Warning: Merging destination map for chart 'airflow'. The destination item 'annotations' is a table and ignoring the source 'annotations' as it has a non-table value of: <nil>
+NAME:   airflow
+LAST DEPLOYED: Wed Aug 14 01:44:55 2019
+NAMESPACE: airflow
+STATUS: DEPLOYED
+
+RESOURCES:
+==> v1/ConfigMap
+NAME                DATA  AGE
+airflow-env         20    <invalid>
+airflow-git-clone   1     <invalid>
+airflow-postgresql  0     <invalid>
+airflow-scripts     1     <invalid>
+
+==> v1/Deployment
+NAME               READY  UP-TO-DATE  AVAILABLE  AGE
+airflow-scheduler  0/1    1           0          <invalid>
+airflow-web        0/1    1           0          <invalid>
+
+==> v1/PersistentVolumeClaim
+NAME                STATUS  VOLUME                                    CAPACITY  ACCESS MODES  STORAGECLASS  AGE
+airflow-postgresql  Bound   pvc-18f4450f-affe-4a84-bdcf-2d1f90d5fe94  8Gi       RWO           nfs-client    <invalid>
+
+==> v1/Pod(related)
+NAME                                READY  STATUS             RESTARTS  AGE
+airflow-postgresql-bdcb64f8d-2x96k  0/1    ContainerCreating  0         <invalid>
+airflow-scheduler-6c59ccf94b-vnwfj  0/1    ContainerCreating  0         <invalid>
+airflow-web-67fc5d65b-bsnjg         0/1    ContainerCreating  0         <invalid>
+
+==> v1/Secret
+NAME                TYPE    DATA  AGE
+airflow-postgresql  Opaque  1     <invalid>
+
+==> v1/Service
+NAME                TYPE       CLUSTER-IP      EXTERNAL-IP  PORT(S)   AGE
+airflow-postgresql  ClusterIP  10.107.163.8    <none>       5432/TCP  <invalid>
+airflow-web         ClusterIP  10.101.175.175  <none>       8080/TCP  <invalid>
+
+==> v1/ServiceAccount
+NAME     SECRETS  AGE
+airflow  1        <invalid>
+
+==> v1beta1/Deployment
+NAME                READY  UP-TO-DATE  AVAILABLE  AGE
+airflow-postgresql  0/1    1           0          <invalid>
+
+==> v1beta1/Ingress
+NAME         HOSTS  ADDRESS  PORTS  AGE
+airflow-web  *      80       <invalid>
+
+==> v1beta1/PodDisruptionBudget
+NAME         MIN AVAILABLE  MAX UNAVAILABLE  ALLOWED DISRUPTIONS  AGE
+airflow-pdb  N/A            1                0                    <invalid>
+
+==> v1beta1/Role
+NAME     AGE
+airflow  <invalid>
+
+==> v1beta1/RoleBinding
+NAME     AGE
+airflow  <invalid>
+
+
+NOTES:
+Congratulations. You have just deployed Apache Airflow
+URL to Airflow and Flower:
+
+    - Web UI: http:///airflow/
+    - Flower: http:///
+```
+
+The 3 containers (`scheduler`, `web` and `postgres`) will take several 
+minutes to come up. Use `kubectl get pods --namespace airflow` to check
+on the pods' statuses. They should look something like this:
+
+```
+NAME                                 READY   STATUS    RESTARTS   AGE
+airflow-postgresql-bdcb64f8d-2x96k   1/1     Running   0          3m45s
+airflow-scheduler-6c59ccf94b-vnwfj   1/1     Running   0          3m45s
+airflow-web-67fc5d65b-bsnjg          1/1     Running   0          3m45s
+```
+
+Provided all goes according to plan, the Airflow WUI should be up at 
+`<Traffic address>/airflow`.
+
+If you need to roll-back: `helm del --purge airflow`. 
+
+**NB** this won't delete the contents of the `dags` and `logs` dirs, 
+thanks to the PVCs created in step (2). Aren't you glad that we did?
+
+## 5. Testing
+### Copying the DAG in
+Copy the [test dag](./resources/opm_test_dag.py) into the `dags` PVC. 
+Use `kubectl get pvc --namespace airflow airflow-dags` to get the volume
+which is bound/serving/linking the PVC.
+
+Result:
+```
+NAME           STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+airflow-dags   Bound    pvc-2c518c23-3bb5-4a91-9991-b9c737f8655e   1Gi        RWX            nfs-client     21m
+```
+
+Using NFS, then the copy command is:
+`cp resources/opm_test_dag.py <path to NFS share>/airflow-airflow-dags-<PVC volume name>`,
+i.e. `cp resources/opm_test_dag.py /data/nfs/airflow-airflow-dags-pvc-2c518c23-3bb5-4a91-9991-b9c737f8655e`.
+
+If you created explicit volumes earlier, the command would be 
+`cp resources/opm_test_dag.py /data/nfs/airflow-dags/`.
+
+And voila, the dag should appear in the WUI, ready to be triggered. This
+might take a few minutes.
+
+### Checking that the dag is working
+By default, the dag is comprised of three tasks, each testing different
+elements of the setup.
+
+Symptom translation:
+* **None of the tasks are running**: the scheduler is unhappy. Inspect its
+logs.
+* **Only one of the tasks are running (`run_this_first`)**: Your scheduler can't
+talk to Kubernetes. Maybe you've locked down the API?
+* **Only two of the three tasks are running (`run_this_first` and `task`)**: Congratulations,
+everything is working as it should. `task2` is failing because it is 
+trying to launch into the default namespace.
+* **All three tasks are running!**: Oh dear, this means that airflow can
+run pods willy-nilly. This probably means your permissions have been overly
+relaxed.

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -219,3 +219,44 @@ trying to launch into the default namespace.
 * **All three tasks are running!**: Oh dear, this means that airflow can
 run pods willy-nilly. This probably means your permissions have been overly
 relaxed.
+
+## 6. Turning on Basic Auth for the WUI (Optional)
+If you're exposing airflow to your whole organisation, you probably want
+to restrict access to the WUI.
+
+In `airflow-values.yaml`, pass in configuration to turn on 
+authentication and set the backend, i.e.
+```yaml
+airflow:
+  config:
+    AIRFLOW__WEBSERVER__AUTHENTICATE: True
+    AIRFLOW__WEBSERVER__AUTH_BACKEND: "airflow.contrib.auth.backends.password_auth"
+```
+
+After you deploy, when navigating to the WUI, you should be greeted by a
+login page demanding credentials.
+
+To generate a user, you will need to run commands on one of the airflow 
+containers directly (so as to inject values into the DB directly). The
+script [airflow_basic_auth_create_user.py](./resources/airflow_basic_auth_create_user.py)
+creates such a user. I will leave it as an exercise to the reader as how
+to get that script into the container (probably easiest to smuggle it
+in via the DAG PVC).
+
+
+Script use: 
+1. Set the SQL Alchemy Env variable: `export AIRFLOW__CORE__SQL_ALCHEMY_CONN=postgresql+psycopg2://postgres:airflow@"$AIRFLOW_POSTGRESQL_SERVICE_HOST":"$AIRFLOW_POSTGRESQL_SERVICE_PORT"/airflow`
+2. Run the script: `python airflow_basic_auth_create_user.py <username> <user email> <password>`
+
+Result:
+```
+[2019-08-14 21:39:09,695] {{settings.py:182}} INFO - settings.configure_orm(): U
+sing pool settings. pool_size=5, pool_recycle=1800, pid=423                     
+/usr/local/lib/python3.7/site-packages/psycopg2/__init__.py:144: UserWarning: Th
+e psycopg2 wheel package will be renamed from release 2.8; in order to keep inst
+alling from binary please use "pip install psycopg2-binary" instead. For details
+ see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.    
+  """) 
+```
+
+And you should be able to log in with the creds created.

--- a/k8s/resources/airflow-values.yaml
+++ b/k8s/resources/airflow-values.yaml
@@ -1,0 +1,61 @@
+airflow:
+  fernetKey: ""
+  service:
+    annotations: {}
+    type: ClusterIP
+    externalPort: 8080
+  executor: Local
+  image:
+    repository: cityofcapetown/airflow
+    tag: kubernetes 
+    pullPolicy: IfNotPresent
+  webReplicas: 1 
+  initdb: true 
+  schedulerNumRuns: "-1"
+
+ingress:
+  enabled: true
+  web:
+    path: "/airflow"
+    host: ""
+    annotations:
+      traefik.frontend.rule.type: PathPrefix
+      kubernetes.io/ingress.class: traefik
+    livenessPath:
+    tls:
+      enabled: false
+
+rbac:
+  create: true 
+
+serviceAccount:
+  create: true 
+  name: airflow 
+
+persistence:
+  enabled: true
+  accessMode: ReadWriteMany
+  existingClaim: "airflow-dags"
+
+logsPersistence:
+  enabled: true
+  accessMode: ReadWriteMany
+  existingClaim: "airflow-logs"
+  
+postgresql:
+  enabled: true
+  service:
+    port: 5432
+  postgresUser: postgres
+  postgresPassword: airflow
+  postgresDatabase: airflow
+  persistence:
+    enabled: true
+    accessMode: ReadWriteOnce
+
+redis:
+  enabled: false
+
+workers:
+  enabled: false
+

--- a/k8s/resources/airflow_basic_auth_create_user.py
+++ b/k8s/resources/airflow_basic_auth_create_user.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+import sys
+
+from airflow import models, settings
+from airflow.contrib.auth.backends.password_auth import PasswordUser
+
+user = PasswordUser(models.User())
+user.username = sys.argv[1]
+user.email = sys.argv[2]
+user.password = sys.argv[3]
+
+session = settings.Session()
+session.add(user)
+session.commit()
+session.close()

--- a/k8s/resources/airflow_namespaces.yaml
+++ b/k8s/resources/airflow_namespaces.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace 
+metadata:
+  name: airflow-workers
+  labels:
+    name: airflow-workers
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: airflow
+  labels:
+    name: airflow

--- a/k8s/resources/airflow_role.yaml
+++ b/k8s/resources/airflow_role.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: airflow-workers
+  name: airflow-role
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["pods", "pods/log"]
+  verbs: ["get", "watch", "list", "create", "delete"]

--- a/k8s/resources/airflow_role_bind.yaml
+++ b/k8s/resources/airflow_role_bind.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: airflow-role-bind
+  namespace: airflow-workers
+subjects:
+- kind: ServiceAccount 
+  name: airflow
+  namespace: airflow
+roleRef:
+  kind: Role
+  name: airflow-role
+  apiGroup: rbac.authorization.k8s.io

--- a/k8s/resources/airflow_volume_claims.yaml
+++ b/k8s/resources/airflow_volume_claims.yaml
@@ -1,0 +1,25 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: airflow-dags
+  namespace: airflow
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: "nfs-client"
+  resources:
+    requests:
+      storage: 1Gi
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: airflow-logs
+  namespace: airflow
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: "nfs-client"
+  resources:
+    requests:
+      storage: 10Gi

--- a/k8s/resources/airflow_volumes.yaml
+++ b/k8s/resources/airflow_volumes.yaml
@@ -1,0 +1,32 @@
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: airflow-dags
+spec:
+  accessModes:
+    - ReadWriteMany
+  capacity:
+    storage: 1Gi
+  nfs:
+    server: 172.29.100.44
+    path: "/data/nfs/airflow-dags"
+  claimRef:
+    namespace: airflow
+    name: airflow-dags
+---
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: airflow-logs
+spec:
+  accessModes:
+    - ReadWriteMany
+  capacity:
+    storage: 10Gi
+  nfs:
+    server: 172.29.100.44
+    path: "/data/nfs/airflow-logs"
+  claimRef:
+    namespace: airflow
+    name: airflow-logs
+---

--- a/k8s/resources/opm_test_dag.py
+++ b/k8s/resources/opm_test_dag.py
@@ -1,0 +1,59 @@
+from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
+from airflow.operators.dummy_operator import DummyOperator
+
+from airflow import DAG
+
+from datetime import datetime, timedelta
+import uuid
+import pprint
+
+DAG_STARTDATE = datetime(2019, 7, 22, 00)
+default_args = {
+    'owner': 'airflow',
+    'depends_on_past': False,
+    'start_date': DAG_STARTDATE,
+    'email': ['gordon.inggs@capetown.gov.za'],
+    'email_on_failure': False,
+    'email_on_retry': False,
+    'retries': 2,
+    'retry_delay': timedelta(minutes=5),
+}
+
+dag_interval = timedelta(minutes=10)
+dag = DAG('opm-test-pipeline',
+          catchup=False,
+          default_args=default_args,
+          schedule_interval=dag_interval,
+          concurrency=2)
+
+
+start = DummyOperator(task_id='run_this_first', dag=dag)
+
+TEST_TASK = 'task'
+k1 = KubernetesPodOperator(namespace='airflow-workers',
+                          image="ubuntu:18.04",
+                          cmds=["bash", "-cx"],
+                          arguments=[f"echo {str(uuid.uuid4())} && cat /etc/*release && sleep 30"],
+                          name="should-run",
+                          task_id=TEST_TASK,
+                          is_delete_operator_pod=True,
+                          get_logs=True,
+                          dag=dag,
+                          in_cluster=True,
+                          )
+
+TEST_TASK2 = 'task2'
+k2 = KubernetesPodOperator(namespace='default',
+                          image="ubuntu:18.04",
+                          cmds=["bash", "-cx"],
+                          arguments=[f"echo {str(uuid.uuid4())} && cat /etc/*release && sleep 30"],
+                          name="shouldnt-run",
+                          task_id=TEST_TASK2,
+                          is_delete_operator_pod=True,
+                          get_logs=True,
+                          dag=dag,
+                          in_cluster=True,
+                          )
+
+k1 << start
+k2 << start


### PR DESCRIPTION
## Overview
We are planning to leave the dirty work of container orchestration to Google's shiny beast. 

Most of the action is in the `./k8s` subdir with various configuration for deploying Airflow to our Kubernetes, so that it can run things inside that same Kubernetes.

## Testing
Ran all instructions in k8s's README on `opm5`. Triggered a DAG via the WUI, while watching the `airflow-workers` namespace.

### Happy Case
All appears to be working as expected:
```bash
$ kubectl get pods --watch -n airflow-workers
should-run-2a76c6c7   0/1   Pending   0     0s
should-run-2a76c6c7   0/1   Pending   0     0s
should-run-2a76c6c7   0/1   ContainerCreating   0     0s
should-run-2a76c6c7   1/1   Running             0     2s
should-run-2a76c6c7   0/1   Completed           0     33s
should-run-2a76c6c7   0/1   Terminating         0     34s
should-run-2a76c6c7   0/1   Terminating         0     34s
```

### Sad Case
Confirmed that `shouldnt-run` task failed, with this error:
```
HTTP response headers: HTTPHeaderDict({'Content-Type': 'application/json', 'X-Content-Type-Options': 'nosniff', 'Date': 'Wed, 14 Aug 2019 01:28:25 GMT', 'Content-Length': '341'})
HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"pods \"shouldnt-run-61bba824\" is forbidden: User \"system:serviceaccount:airflow:airflow\" cannot delete resource \"pods\" in API group \"\" in the namespace \"default\"","reason":"Forbidden","details":{"name":"shouldnt-run-61bba824","kind":"pods"},"code":403}
```